### PR TITLE
fix: teardown errors

### DIFF
--- a/.github/workflows/scheduled-tests.yml
+++ b/.github/workflows/scheduled-tests.yml
@@ -40,10 +40,11 @@ jobs:
           ./webhook.py "${{ vars.WEBHOOK_URL }}" "${{ github.repository }}" "${{ github.run_id }}"
       - name: CLEAN_BUCKETS
         if: always()
+        continue-on-error: true
         run: |
           for profile in ${{ vars.PROFILES_TO_CLEAN }}; do
             aws s3 ls --profile $profile | grep "test-" | awk '{print $3}' | while read -r bucket; do
-              aws s3 rb s3://$bucket --profile $profile --force
+              rclone purge "$profile:$bucket"
             done
           done
 

--- a/spec/053_utils.sh
+++ b/spec/053_utils.sh
@@ -12,8 +12,7 @@ remove_test_bucket(){
   profile=$1
   bucket_name=$(get_test_bucket_name)
   if [[ -z $TEST_BUCKET_NAME ]];then
-    #echo "removing bucket $bucket_name..."
-    aws --profile "$profile" s3 rb "s3://${bucket_name}" --force > /dev/null
+    rclone purge --log-file /dev/null "$profile:$bucket_name" > /dev/null
   else
     rclone_objects=""
     for file in $FILES; do


### PR DESCRIPTION
As part of the efforts to reduce the number of scheduled tests that errors due to intermittent instabilities, this patch changes the way we remove buckets as the teardown stage for tests 53,57,61,62,63. Instead of using aws s3 rb --force that still ended with BucketNotEmpty outputs sometimes, we now use rclone purge with both stderr and stdout redirected to /dev/null

We might end up with garbage buckets on the account if this teardown fails, but there is already a script to cleanup this garbage before (or after?) each run.