### PR TITLE
fix: breaking change on new mgccli version

### DIFF
--- a/spec/053_upload-files_spec.sh
+++ b/spec/053_upload-files_spec.sh
@@ -188,7 +188,7 @@ Describe 'Delete' category:"Object Management"
       ;;
     "mgc")
       mgc profile set-current $profile > /dev/null
-      When run mgc --debug object-storage objects delete --dst="$BUCKET_NAME/$object_key" --cli.bypass-confirmation
+      When run mgc --debug object-storage objects delete --dst="$BUCKET_NAME/$object_key" --no-confirm
       The status should be success
       The error should include "$BUCKET_NAME?delete="
       The error should include "200 OK"

--- a/spec/064_delete-versioned-object_spec.sh
+++ b/spec/064_delete-versioned-object_spec.sh
@@ -92,7 +92,7 @@ Describe "Delete versioned object" category:"Object Management" id:"064"
       ;;
     "mgc")
       mgc profile set-current $profile > /dev/null
-      When run mgc --debug object-storage objects delete --dst="$bucket_name/$key" --cli.bypass-confirmation
+      When run mgc --debug object-storage objects delete --dst="$bucket_name/$key" --no-confirm
       The status should be success
       The error should include "$bucket_name?delete="
       The error should include "200 OK"


### PR DESCRIPTION
The flag --cli.bypas-confirmation no longer exists the objects delete now uses --no-confirm instead.