### PR TITLE
disable bot alerts

### DIFF
--- a/.github/workflows/scheduled-tests.yml
+++ b/.github/workflows/scheduled-tests.yml
@@ -42,11 +42,11 @@ jobs:
           mgc --version
           sha256sum `which mgc`
           ./entrypoint.sh test.sh --profiles "${{ vars.CRON_PROFILES_3 }}" --tests "${{ vars.CRON_TESTS_3 }}" --clients "${{ vars.CRON_CLIENTS_3 }}" -- --env NUMBER_OF_WAITS=${{ vars.NUMBER_OF_WAITS }} --env SKIP_KNOWN_ISSUES=${{ vars.SKIP_KNOWN_ISSUES }} --color
-      - name: webhook send
-        if: always()
-        run: |
-          cd /app
-          ./bin/webhook.py "${{ vars.WEBHOOK_URL }}" "${{ vars.WEBHOOK_CLEAN_URL }}" "${{ github.repository }}" "${{ github.run_id }}" "${{ vars.TOKEN }}"
+        #     - name: webhook send
+        #       if: always()
+        #       run: |
+        #         cd /app
+        #         ./bin/webhook.py "${{ vars.WEBHOOK_URL }}" "${{ vars.WEBHOOK_CLEAN_URL }}" "${{ github.repository }}" "${{ github.run_id }}" "${{ vars.TOKEN }}"
       - name: Upload results.tap artifact
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Bot alerts are no longer useful since they are reporting successful tests as well so I am temporarily disabling them until we can either fix the false negatives.